### PR TITLE
Reduce size from 496 MB -> 401 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
+
+EXPOSE 1337
 
 LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
       org.label-schema.vendor="Strapi" \
@@ -11,20 +13,16 @@ LABEL maintainer="Luca Perret <perret.luca@gmail.com>" \
 
 WORKDIR /usr/src/api
 
-RUN apt-get update
-RUN apt-get -y install curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash -
-RUN apt-get -y install nodejs
+RUN apt-get update && apt-get install -yqq curl gnupg
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+      echo 'deb https://deb.nodesource.com/node_10.x bionic main' > /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get -yqq install nodejs && apt-get remove -yqq curl gnupg && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g strapi@beta --unsafe-perm=true --allow-root
-RUN strapi -v
+RUN npm install -g strapi@beta --unsafe-perm=true --allow-root && npm cache clean --force
 
-COPY strapi.sh ./
+COPY strapi.sh healthcheck.js ./
 RUN chmod +x ./strapi.sh
 
-EXPOSE 1337
-
-COPY healthcheck.js ./
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s \
       CMD node /usr/src/api/healthcheck.js
 


### PR DESCRIPTION
Biggest change was to clean the npm cache after install, otherwise every downloaded tarball would have stayed there. This saved a whopping 70 MB off the image.. Next best thing was to reduce the number of layers by combining RUN statements. Finally, removing unneeded packages (curl and gnupg) and clearing the APT cache shaved some additional 10 MB.

I've also replaced the install script with just the right lines from it, saves from downloading and executing a script designed for end-users, and not containers.